### PR TITLE
Release fixes: shipped cheats, overwritten settings, destroyed keybinds

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -220,6 +220,14 @@ jobs:
           $rtgl = Get-Content "$p\rt\RTGL1.json" -Raw | ConvertFrom-Json
           if (-not $rtgl.developerMode) { throw 'RTGL1.json: developerMode is off - authored materials would be ignored' }
           if ($rtgl.debugWindows)       { throw 'RTGL1.json: debugWindows is on - the release would open the debug window' }
+          # NO CHEATS AND NO VIDEO OVERRIDES IN THE SHIPPED PINS. The pins file is
+          # written for the tester's launcher and its head carries sv_cheats/god/
+          # notarget plus a windowed block; the release launcher execs the same file.
+          # v0.1.0-v0.1.6 all shipped an invulnerable game that monsters ignored.
+          # package_release.py strips the marked DEV-ONLY block -- this proves it did.
+          foreach ($bad in 'sv_cheats','god','notarget','vid_fullscreen','win_x','queryiwad') {
+            if ($pins -match "(?m)^$bad( |$)") { throw "d64rt-pins.cfg still pins '$bad' - the DEV-ONLY strip did not run" }
+          }
           # Nothing that belongs to somebody else's game, and nothing we cannot ship.
           foreach ($f in @('D64RTR_v15.WAD','D64MUS.PK3','doom2.wad','DOOMSND.SF2','D64RTR_BRIGHTMAPS.PK3')) {
             if (Get-ChildItem $p -Recurse -Filter $f -ErrorAction SilentlyContinue) {

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ this project is finding those and replacing them with something that actually em
 | **Clouds + lightning** | A layered cloud deck (`rt_clouds_*`): 6–8 baked slices drawn as stacked sky-dome shells, so they parallax and occlude each other. It is sky *geometry*, not a participating medium — but moonlight is tinted and attenuated through the stack, and it flashes with MAP11's storm, whose schedule this puts back. `thunder` CCMD. | [`rt-clouds-and-lightning`](docs/rt-clouds-and-lightning.md) |
 | **Per-map fog** | A froxel volume with a near/far ramp, tuned per level (`rt_fog_*`, `RT_FOG_PRESETS`, `fog` CCMD). Needed two RTGL1 froxel changes. | [`rt-fog`](docs/rt-fog.md) · [implementation](docs/rt-fog-implementation.md) |
 | **Volumetric smoke** | Muzzle smoke as a real participating medium inside the fog's froxel volume, so it takes the colour of whatever lights the room. Six sources: weapons, monster guns, projectiles, barrels, flames. Sim is on the CPU, on purpose. `smoke` CCMD. | [`rt-smoke`](docs/rt-smoke.md) |
-| **Light shafts from lamps** | The froxel pass shadow-tests one light per frame — the sun — which is why beams only ever happened outdoors. An explicit fixture list puts ordinary ceiling lamps, bulb lattices and solo bulbs in the air too (`rt_volume_shafts`, `rt_volume_shaft_src` as a family bitmask). | [`plan-light-shafts`](docs/plan-light-shafts.md) |
+| **Light shafts from lamps** | The froxel pass shadow-tests one light per frame — the sun — which is why beams only ever happened outdoors. An explicit fixture list puts ordinary ceiling lamps, bulb lattices and solo bulbs in the air too (`rt_volume_shafts`, `rt_volume_shaft_src` as a family bitmask). | [`plan-light-shafts`](docs/plan-light-shafts.md) *(shipped; the doc is the design)* |
 | **Dust motes** | Tiny quads on a hashed world grid, drawn where a shaft can actually light them (`rt_dust_*`). Bounded by construction: the cap sets the cell spacing rather than a counter. | — |
 | **Water** | Stylized surface with projected caustics; flats are tagged engine-side, no per-map setup. | [`rt-water`](docs/rt-water.md) |
 | **Lava** | The floor is the emitter — drifting quantized heat field (`rt_lava_flow*`), slow whole-surface breath, optional analytic light grid over the flats. | — |
@@ -170,7 +170,8 @@ works on the WAD's own classes.
 - **Projectile impacts** (`rt_arc_*`) — that hitscan hook is hitscan only, so no projectile
   in the game reacted to what it hit. Plasma, the arachnotron's bolt and the BFG now leave
   a branching electric mark with its own light and its own colour ramp.
-  → [`docs/plan-projectile-impact-fx.md`](docs/plan-projectile-impact-fx.md)
+  → [`docs/plan-projectile-impact-fx.md`](docs/plan-projectile-impact-fx.md) — shipped;
+  the doc is the design, and records what was deliberately left out.
 - **The Unmaker burns the wall** (`rt_laser_*`) — its laser leaves a hot spot, a glow and
   a short-lived arc where it lands, rather than passing through the world unmarked.
 - **Exploding barrels** (`rt_barrel_*`) — the barrel comes apart into curved plate pieces
@@ -245,17 +246,19 @@ console fires one on demand if you want to reproduce it.
 ## ⛧ &nbsp;Install and play
 
 > [!NOTE]
-> **v0.1.0 is a pre-release.** It builds and runs here, but nobody outside this
-> machine has played it: the FSR path has never run on AMD hardware, and DLSS Ray
-> Reconstruction is alpha and ships off. Bug reports welcome.
+> **Tested on one machine only.** The FSR path has never run on AMD hardware, and DLSS Ray
+> Reconstruction is alpha and ships off. Releases cut from `main` are full releases;
+> anything tagged off another branch publishes as a `(beta)` pre-release. Bug reports
+> welcome.
 
 You need a GPU with hardware ray tracing (NVIDIA RTX, AMD RDNA 2+, Intel Arc) and
 a DOOM II you own. Everything else is free.
 
 **1. Download and extract this**
 
-[**Releases**](https://github.com/jlrouzies-fr/doom64-rt/releases) → `Doom64-RT.zip` (~110 MB).
-Extract it anywhere — it needs no installer and writes nothing outside its own folder.
+[**Releases**](https://github.com/jlrouzies-fr/doom64-rt/releases) → `Doom64-RT.zip` (~124 MB).
+Extract it anywhere — it needs no installer, and the only thing it writes outside its own
+folder is GZDoom's config, at `Documents\My Games\GZDoom\gzdoom-rt2.ini`.
 
 **2. Get Doom 64: Retribution and its music, and extract both into `game\`**
 
@@ -345,11 +348,11 @@ the clone can live anywhere.
 > branch** — not their upstreams. Both carry changes this repo depends on (the RT feature
 > file split, the froxel changes fog and smoke need, the emissive and translation fixes).
 > Upstream will build, then behave wrong in ways nothing reports.
-> **The project repo itself is on `fileSplit`** — its `main` branch is an empty initial
-> commit, so a plain `git clone` gets you a README and nothing else.
+> The project repo itself is on **`main`**; `dev` is where work lands before it is merged
+> and tagged.
 
 ```powershell
-git clone -b fileSplit https://github.com/jlrouzies-fr/doom64-rt.git Doom64-RT
+git clone https://github.com/jlrouzies-fr/doom64-rt.git Doom64-RT
 cd Doom64-RT
 git clone --recurse-submodules -b doom64-rt https://github.com/jlrouzies-fr/gzdoom-rt.git sourcecode\gzdoom-rt
 git clone --recurse-submodules -b doom64-rt https://github.com/jlrouzies-fr/RTGL.git      deps\RTGL
@@ -408,7 +411,7 @@ after any clean rebuild because the stock `rt\` tree is restaged wholesale:
 
 | Step | Why it matters |
 |---|---|
-| writes `rt\RTGL1.json` with `developerMode: true` | RTGL1 only ever **reads** this file (`VulkanDevice_Init.cpp:228`, `.value_or(default)`). No file means `developerMode: false`, every authored PNG material ignored, KTX2 only — and nothing warns you. The game just looks stock. |
+| writes `rt\RTGL1.json` with `developerMode: true` | RTGL1 only ever **reads** this file (`VulkanDevice_Init.cpp:228`, `.value_or(default)`). No file means `developerMode: false`, every authored PNG material ignored, KTX2 only — and nothing warns you. The game just looks stock. A **release** additionally gets `debugWindows: false`: the two used to be one flag, so hiding RTGL1's ImGui window meant giving up the authored materials. |
 | stages `Retribution-RT-Materials\rt\` into the engine `rt\` | The materials themselves. |
 | copies `rt-wad-overlay\` into `rt\wad` | `rt\wad` is appended **after** every `-file` PWAD, so without it the stock RT menu art overrides Retribution's. |
 
@@ -444,7 +447,7 @@ build it.
 </table>
 
 > [!NOTE]
-> The launcher pins ~390 cvars via `+exec tools\d64rt-pins.cfg` rather than on the command line.
+> The launcher pins ~600 cvars via `+exec tools\d64rt-pins.cfg` rather than on the command line.
 > That is deliberate: `cmd.exe` truncates at 8191 characters, and the old inline form silently
 > dropped the tail — arms ran on defaults while the tool printed values it never applied.
 
@@ -465,7 +468,7 @@ Three that matter more than the rest:
 
 | | |
 |---|---|
-| [`AGENTS.md`](AGENTS.md) | The working handbook — diagnostic procedure for a wrongly-lit surface, the `rt/` source map, how to add a cvar, and 31 numbered pitfalls not to repeat. |
+| [`AGENTS.md`](AGENTS.md) | The working handbook — diagnostic procedure for a wrongly-lit surface, the `rt/` source map, how to add a cvar, and 36 numbered pitfalls not to repeat. |
 | [`compat-patches.md`](compat-patches.md) | Every engine and RTGL1 change we made, dated, with the reason. |
 | [`docs/open-issues-rt-lighting.md`](docs/open-issues-rt-lighting.md) | What still fails. |
 

--- a/launch-doom64-rt.cmd
+++ b/launch-doom64-rt.cmd
@@ -141,6 +141,16 @@ echo   iwad      : %IWAD%
 echo   upscaler  : %D64RT_UPSCALER%   ^(override with D64RT_UPSCALER=dlss^|fsr^|none^)
 echo.
 
+rem NO -width/-height ON THIS LINE, and no `rem` inside it either -- a rem
+rem between two ^-continued lines is not a comment, it becomes ARGUMENTS, and the
+rem first line without a caret silently truncates the command (that is how
+rem -rtnolauncher and +exec pins got dropped once).
+rem
+rem The resolution flags are a COMMAND-LINE OVERRIDE applied after the config is
+rem read, so passing them every start undid whatever the player chose in the
+rem menus: set it, save, restart, back to 1280x720. The window size is theirs to
+rem keep. tools\launch-retribution-rt.cmd still forces it, on purpose -- a test
+rem launcher wants a predictable window.
 cd /d "%ENGINE%"
 start "" "%ENGINE%\gzdoom.exe" -iwad "%IWAD%" ^
   -file "%MOD%" "%GAME%\D64RTR_BRIGHTMAPS.PK3" "%GAME%\D64MUS.PK3" ^
@@ -150,11 +160,6 @@ start "" "%ENGINE%\gzdoom.exe" -iwad "%IWAD%" ^
   "%MODS%\d64r-ctel-fix.wad" "%MODS%\d64r-rt-sky.pk3" ^
   -file "%MODS%\d64r-lava-fx.pk3" "%MODS%\d64r-blood-persist.pk3" ^
   "%MODS%\d64r-widescreen-gfx.pk3" "%MODS%\d64r-mugshot.pk3" "%MODS%\d64r-rt-titlelogo.pk3" ^
-  rem NO -width/-height HERE. They are a COMMAND-LINE OVERRIDE, applied after
-  rem the config is read and before the first frame, so passing them every start
-  rem silently undid whatever resolution the player picked in the menus -- they
-  rem set it, saved it, restarted, and got 1280x720 back. The window size is the
-  rem player's to keep; the config already remembers it.
   -rtnolauncher ^
   +exec "%PINS%" %UPSCALE% %MAPARG%%REST%
 

--- a/launch-doom64-rt.cmd
+++ b/launch-doom64-rt.cmd
@@ -150,7 +150,12 @@ start "" "%ENGINE%\gzdoom.exe" -iwad "%IWAD%" ^
   "%MODS%\d64r-ctel-fix.wad" "%MODS%\d64r-rt-sky.pk3" ^
   -file "%MODS%\d64r-lava-fx.pk3" "%MODS%\d64r-blood-persist.pk3" ^
   "%MODS%\d64r-widescreen-gfx.pk3" "%MODS%\d64r-mugshot.pk3" "%MODS%\d64r-rt-titlelogo.pk3" ^
-  -rtnolauncher -width 1280 -height 720 ^
+  rem NO -width/-height HERE. They are a COMMAND-LINE OVERRIDE, applied after
+  rem the config is read and before the first frame, so passing them every start
+  rem silently undid whatever resolution the player picked in the menus -- they
+  rem set it, saved it, restarted, and got 1280x720 back. The window size is the
+  rem player's to keep; the config already remembers it.
+  -rtnolauncher ^
   +exec "%PINS%" %UPSCALE% %MAPARG%%REST%
 
 endlocal

--- a/tools/d64rt-pins.cfg
+++ b/tools/d64rt-pins.cfg
@@ -3,12 +3,22 @@
 // line 8016 characters and cmd.exe truncates at 8191 -- which silently ate the
 // "-- +cvar" A/B passthrough at the end of the line, and some of these pins.
 // Edit values here; the launcher execs this file before +map.
+// >>> DEV-ONLY <<<  Everything down to END-DEV-ONLY is STRIPPED by
+// tools/package_release.py and must never reach a player. These make the game
+// convenient to TEST -- windowed, no IWAD prompt, unkillable, ignored by
+// monsters -- and a shipped build with them is a shipped build you cannot lose.
+//
+// Do not move a line out of this block without deciding it is right for someone
+// playing the game for the first time. vid_fullscreen and win_x are in here
+// because a launcher that reasserts them every start overwrites whatever the
+// player chose in the menus, which reads as "my settings do not save".
 vid_fullscreen 0
 win_x -1
 queryiwad false
 sv_cheats 1
 god
 notarget
+// >>> END-DEV-ONLY <<<
 // NO `give` HERE, and it was tried. `god` and `give` look identical in the
 // source -- both are CheckCheatmode() then Net_WriteByte(DEM_*) -- so it is
 // reasonable to expect one to work wherever the other does. It does not: from

--- a/tools/launch-unseenevil-rt.cmd
+++ b/tools/launch-unseenevil-rt.cmd
@@ -47,6 +47,20 @@ set "ENGINE=%PROJ%\sourcecode\gzdoom-rt\build\RelWithDebInfo"
 set "MOD=%PROJ%\Doom64-UnseenEvil\D64UnseenEvil-v1.0.3.pk3"
 set "TONE=%PROJ%\Doom64-UnseenEvil\d64ue-brightmap-tone.pk3"
 
+rem ---- autolights -----------------------------------------------------------
+rem WHY THIS IS NEEDED AT ALL. DOOM 1 and DOOM 2 maps contain no light things --
+rem their rooms are lit purely by sector lightlevel, which is baked shading, not
+rem a light source. Under a path tracer that leaves the world essentially black:
+rem rt_sector_emis only makes a bright surface glow on itself, and the engine's
+rem fixture walk keys off Doom 64 texture names this content does not use.
+rem d64rt-autolights.pk3 spawns one PointLight per lit sector, which GZDoom
+rem forwards into RTGL1 through the same path Retribution's 9800 things use.
+rem
+rem It is STILL BEING TUNED -- it currently reads a little hot in MAP01's opening
+rem corridor -- so "nolights" drops it without dropping the tone overlay, which is
+rem what makes the two separable when judging a room.
+set "AUTO=%PROJ%\Doom64-UnseenEvil\d64rt-autolights.pk3"
+
 rem ---- Retribution patches carried over -------------------------------------
 rem WHICH OF OURS TRANSFER, AND WHY MOST DO NOT. Every d64r-*.pk3 was checked for
 rem what it inherits from and replaces. The great majority are Retribution-shaped
@@ -101,8 +115,9 @@ rem time its own test was reached, so it fell through to the map parser and beca
 rem "+map bare". Consuming them in a loop removes the ordering entirely.
 set "WANT=doom2.wad"
 :flags
-if /i "%~1"=="bare"  ( set "PATCHES=" & shift & goto :flags )
+if /i "%~1"=="bare"  ( set "PATCHES=" & set "AUTO=" & shift & goto :flags )
 if /i "%~1"=="doom1" ( set "WANT=doom.wad" & shift & goto :flags )
+if /i "%~1"=="nolights" ( set "AUTO=" & shift & goto :flags )
 
 rem Steam's modern "Ultimate Doom" depot is a BUNDLE: one app folder holds every
 rem classic IWAD, with DOOM.WAD at base\ and the rest one level down in
@@ -148,6 +163,9 @@ if not exist "%TONE%" (
   echo        Build it with: python tools\tone_unseenevil_brightmaps.py --write
   exit /b 1
 )
+rem Absent is not an error: it is gitignored, and "nolights" clears it on purpose.
+if not exist "%AUTO%" set "AUTO="
+if defined AUTO set "AUTO="%AUTO%""
 
 rem ---- passthrough ----------------------------------------------------------
 rem Collect the post-"--" passthrough without disturbing %1 parsing above.
@@ -199,6 +217,7 @@ echo   iwad    %IWAD%
 echo   mod     %MOD%
 echo   tone    %TONE%   ^(18 brightmaps 255 -^> 192^)
 if defined PATCHES (echo   patches %PATCHES%) else (echo   patches none ^("bare"^))
+if defined AUTO (echo   lights  autolights ON) else (echo   lights  none ^("nolights"^))
 echo   map     %MAPLUMP%
 echo   log     %LOGF%
 echo.
@@ -225,8 +244,12 @@ rem Keep this command line SHORT. The Retribution launcher once spelled every
 rem pin out here, hit cmd.exe's 8191-character limit, and silently dropped the
 rem trailing passthrough while still printing the values it believed it had set.
 rem That is why the pins live in a cfg and arrive via +exec.
+rem WINDOWED 960x540, PINNED TOP-LEFT. -width/-height set the RENDER size and do
+rem not size the window at all; only vid_defwidth/vid_defheight do, which is why
+rem the old line above them still opened a full-desktop window.
 start "" gzdoom.exe ^
-  -iwad "%IWAD%" -file "%MOD%" %PATCHES% "%TONE%" -rtnolauncher -nostartup -width 1280 -height 720 ^
+  -iwad "%IWAD%" -file "%MOD%" %PATCHES% "%TONE%" %AUTO% -rtnolauncher -nostartup ^
+  +vid_fullscreen 0 +vid_defwidth 960 +vid_defheight 540 +win_x 0 +win_y 0 ^
   +logfile "%LOGF%" ^
   +exec "%PINS%" ^
   %MAPARG% %MAPLUMP% %EXTRA%

--- a/tools/package_release.py
+++ b/tools/package_release.py
@@ -160,7 +160,30 @@ def main():
             sys.exit("missing mod file the launcher requires: " + name)
         shutil.copy2(p, mods / name)
         count += 1
-    shutil.copy2(PROJ_ROOT / "tools" / "d64rt-pins.cfg", mods / "d64rt-pins.cfg")
+    # THE PINS ARE A DEVELOPMENT FILE AND MUST BE FILTERED, NOT COPIED.
+    # d64rt-pins.cfg is written for launch-retribution-rt.cmd -- the tester's
+    # launcher -- and its head carries `sv_cheats 1`, `god` and `notarget`, plus
+    # a windowed/no-prompt video block. The release launcher execs the same file,
+    # so a straight copy shipped every player an invulnerable game that monsters
+    # ignore, and reasserted the window size over whatever they chose in the
+    # menus. Strip the marked block instead.
+    pins_src = (PROJ_ROOT / "tools" / "d64rt-pins.cfg").read_text(encoding="utf-8")
+    kept, dropped, skipping = [], 0, False
+    for line in pins_src.splitlines(keepends=True):
+        if ">>> DEV-ONLY <<<" in line:
+            skipping = True
+        if skipping:
+            dropped += 1
+            if ">>> END-DEV-ONLY <<<" in line:
+                skipping = False
+            continue
+        kept.append(line)
+    if skipping:
+        sys.exit("d64rt-pins.cfg: DEV-ONLY block is never closed - refusing to ship it")
+    if dropped == 0:
+        sys.exit("d64rt-pins.cfg: no DEV-ONLY block found - the cheat pins would ship")
+    (mods / "d64rt-pins.cfg").write_text("".join(kept), encoding="utf-8")
+    print("  pins        stripped %d dev-only line(s)" % dropped)
     print("  mods/       %5d files" % (count + 1))
 
     # --- launcher + docs ---------------------------------------------------


### PR DESCRIPTION
Three player-visible bugs, plus the README notes the branch work made stale.

**Releases shipped god mode.** `d64rt-pins.cfg` is the *tester's* pin list — it carries
`sv_cheats 1`, `god` and `notarget` — and the packager copied it verbatim into the release,
where the release launcher execs it. v0.1.0 through v0.1.6 all started invulnerable with
monsters ignoring the player. The dev pins are now wrapped in a `>>> DEV-ONLY <<<` block the
packager strips, refusing to ship if the block is missing rather than shipping cheats
quietly, and CI rejects a package whose pins still carry any of them. `tools\*.cmd` keep
them, unchanged.

**The launcher overwrote the player's settings.** It passed `-width 1280 -height 720` on
every start, applied after the config is read, so a resolution set in the menus was silently
undone on the next launch. Removed from the release launcher only.

**"Save current settings" destroyed the key it had just saved.** `ArchiveBindings` runs
twice per save; the custom-key-section pass marked each key it wrote by *overwriting the
binding* with `"\1"`, and the general pass turned that marker into `""`. So binding the
flashlight and saving emptied it in memory — the key stopped working and the menu showed no
shortcut until a restart. Same two-pass contract, recorded in a `bool[]` beside the
bindings instead of on top of them. Upstream bug; affects every mod using `addkeysection`.

**Stock Doom II rendered as pure sky** — whether a map needs live geometry upload was
decided by "name contains `_`", which assumed every plain `map01` has a baked scene. It asks
the filesystem now.

**README** — eight stale notes, including clone instructions that no longer worked at all.
